### PR TITLE
Integrate Calendly booking system

### DIFF
--- a/index.html
+++ b/index.html
@@ -483,12 +483,10 @@
             <div class="grid md:grid-cols-5 gap-8 items-start">
                 <!-- Calendly Embed - Left Column (60%) -->
                 <div class="md:col-span-3 order-1">
-                    <div class="rounded-3xl shadow-xl overflow-hidden">
-                        <!-- Calendly inline widget begin -->
-                        <div class="calendly-inline-widget" data-url="https://calendly.com/rociotouzasanchez/30min?hide_event_type_details=1&text_color=1d3557&primary_color=80cbc4" style="position: relative;min-width:320px;height:700px;"></div>
-                        <script type="text/javascript" src="https://assets.calendly.com/assets/external/widget.js" async></script>
-                        <!-- Calendly inline widget end -->
-                    </div>
+                    <!-- Calendly inline widget begin -->
+                    <div class="calendly-inline-widget" data-url="https://calendly.com/rociotouzasanchez/30min?hide_event_type_details=1&text_color=1d3557&primary_color=80cbc4" style="position: relative;min-width:320px;height:700px;"></div>
+                    <script type="text/javascript" src="https://assets.calendly.com/assets/external/widget.js" async></script>
+                    <!-- Calendly inline widget end -->
                 </div>
 
                 <!-- Contact Information - Right Column (40%) -->


### PR DESCRIPTION
## Summary

Redesigns the Contact section to prioritize booking with Calendly integration:

**Desktop layout:**
```
┌─────────────────────────┬──────────────────┐
│                         │ ¿Prefieres       │
│   [Calendly Embed]      │ escribirme?      │
│       (60%)             │                  │
│                         │ WhatsApp         │
│                         │ Email            │
│                         │ Ubicación        │
└─────────────────────────┴──────────────────┘
```

**Mobile layout:**
- Calendly section first (stacked)
- Contact options below
- Sticky "Reservar sesión" bar at bottom (always visible)

**Changes:**
- Section renamed: "Contacto" → "Reserva tu sesión"
- Removed Google Maps (less relevant for online-only therapy)
- Floating button: WhatsApp → "Reservar" (scrolls to booking)
- Nav links updated: "Contacto" → "Reservar"
- Contact cards now clickable with hover states

## Action Required

Replace Calendly placeholder (line ~505-515) with actual Calendly iframe embed code.

## Test plan

- [ ] Desktop: Verify 60/40 grid layout
- [ ] Mobile: Verify Calendly first, contacts below
- [ ] Mobile: Verify sticky bottom bar visibility
- [ ] Click "Reservar" floating button scrolls to section
- [ ] Click contact cards (WhatsApp, Email) work
- [ ] Language switcher updates new text elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)