### PR TITLE
fix: calendly widget appearance

### DIFF
--- a/index.html
+++ b/index.html
@@ -510,13 +510,11 @@
                 Elige el día y hora que mejor te funcione. Recibirás un email de confirmación con el enlace de Google Meet.
             </p>
 
-            <!-- Calendly Widget -->
-            <div class="bg-white rounded-2xl shadow-lg overflow-hidden mb-12">
-                <!-- Calendly inline widget begin -->
-                <div class="calendly-inline-widget" data-url="https://calendly.com/rociotouzasanchez/30min?hide_event_type_details=1&background_color=f9f7f3&text_color=1d3557&primary_color=ff6f61" style="min-width:320px;height:700px;"></div>
-                <script type="text/javascript" src="https://assets.calendly.com/assets/external/widget.js" async></script>
-                <!-- Calendly inline widget end -->
-            </div>
+            <!-- Calendly inline widget begin -->
+            <div class="calendly-inline-widget" data-url="https://calendly.com/rociotouzasanchez/30min?hide_event_type_details=1"
+                style="min-width:320px;height:710px;;"></div>
+            <script type="text/javascript" src="https://assets.calendly.com/assets/external/widget.js" async></script>
+            <!-- Calendly inline widget end -->
 
             <!-- Alternative Contact Options -->
             <div class="text-center">


### PR DESCRIPTION
- increase height by 10px to avoid vertical scrollbar
- avoid personalization colors that generates grey background