### PR TITLE
Add Doctoralia anonymous review link

### DIFF
--- a/src/_data/en.json
+++ b/src/_data/en.json
@@ -227,7 +227,7 @@
     "doctoraliaNote": "Prefer to stay anonymous? You can also share your experience on Doctoralia.",
     "doctoraliaCtaText": "Review on Doctoralia",
     "doctoraliaAriaLabel": "Leave a review on Doctoralia",
-    "doctoraliaUrl": "PLACEHOLDER_DOCTORALIA_URL"
+    "doctoraliaUrl": "https://www.doctoralia.es/anade-opinion/rocio-touza-sanchez-4#/opinion"
   },
   "book": {
     "title": "Book your session",

--- a/src/_data/en.json
+++ b/src/_data/en.json
@@ -222,7 +222,12 @@
     "title": "About the therapeutic process",
     "subtitle": "Your experience can help others find the support they need. If you'd like to share something about your current or past therapeutic experience, you can leave a few words here - do so with complete freedom, it's simply an option for those who wish to do so.",
     "ctaText": "Share my experience",
-    "googleMapsUrl": "https://g.page/r/CRpj352A4OBHEBI/review"
+    "googleMapsAriaLabel": "Leave a review on Google Maps",
+    "googleMapsUrl": "https://g.page/r/CRpj352A4OBHEBI/review",
+    "doctoraliaNote": "Prefer to stay anonymous? You can also share your experience on Doctoralia.",
+    "doctoraliaCtaText": "Review on Doctoralia",
+    "doctoraliaAriaLabel": "Leave a review on Doctoralia",
+    "doctoraliaUrl": "PLACEHOLDER_DOCTORALIA_URL"
   },
   "book": {
     "title": "Book your session",

--- a/src/_data/es.json
+++ b/src/_data/es.json
@@ -227,7 +227,7 @@
     "doctoraliaNote": "¿Prefieres el anonimato? También puedes compartir tu experiencia en Doctoralia.",
     "doctoraliaCtaText": "Reseña en Doctoralia",
     "doctoraliaAriaLabel": "Dejar reseña en Doctoralia",
-    "doctoraliaUrl": "PLACEHOLDER_DOCTORALIA_URL"
+    "doctoraliaUrl": "https://www.doctoralia.es/anade-opinion/rocio-touza-sanchez-4#/opinion"
   },
   "book": {
     "title": "Reserva tu sesión",

--- a/src/_data/es.json
+++ b/src/_data/es.json
@@ -222,7 +222,12 @@
     "title": "Sobre el proceso terapéutico",
     "subtitle": "Tu experiencia puede ayudar a otros a encontrar el apoyo que necesitan. Si te gustaría compartir algo de tu experiencia terapéutica actual o pasada, puedes dejar unas palabras aquí - hazlo con total libertad, es simplemente una posibilidad para quienes deseen hacerlo.",
     "ctaText": "Compartir mi experiencia",
-    "googleMapsUrl": "https://g.page/r/CRpj352A4OBHEBI/review"
+    "googleMapsAriaLabel": "Dejar reseña en Google Maps",
+    "googleMapsUrl": "https://g.page/r/CRpj352A4OBHEBI/review",
+    "doctoraliaNote": "¿Prefieres el anonimato? También puedes compartir tu experiencia en Doctoralia.",
+    "doctoraliaCtaText": "Reseña en Doctoralia",
+    "doctoraliaAriaLabel": "Dejar reseña en Doctoralia",
+    "doctoraliaUrl": "PLACEHOLDER_DOCTORALIA_URL"
   },
   "book": {
     "title": "Reserva tu sesión",

--- a/src/_includes/components/booking.njk
+++ b/src/_includes/components/booking.njk
@@ -67,11 +67,24 @@
            target="_blank"
            rel="noopener noreferrer"
            class="inline-flex items-center gap-2 px-6 py-3 bg-forest-green/90 text-white rounded-full font-semibold hover:bg-forest-green transition shadow-md hover:shadow-lg hover:-translate-y-1 duration-200"
-           aria-label="{% if lang == 'es' %}Dejar reseña en Google Maps{% else %}Leave review on Google Maps{% endif %}">
+           aria-label="{{ t.reviews.googleMapsAriaLabel }}">
             <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
                 <path d="M14.06,9L15,9.94L5.92,19H5V18.08L14.06,9M17.66,3C17.41,3 17.15,3.1 16.96,3.29L15.13,5.12L18.88,8.87L20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18.17,3.09 17.92,3 17.66,3M14.06,6.19L3,17.25V21H6.75L17.81,9.94L14.06,6.19Z"/>
             </svg>
             <span>{{ t.reviews.ctaText }}</span>
+        </a>
+
+        <!-- Doctoralia secondary CTA -->
+        <p class="mt-6 text-sm text-gray-500">{{ t.reviews.doctoraliaNote }}</p>
+        <a href="{{ t.reviews.doctoraliaUrl }}"
+           target="_blank"
+           rel="noopener noreferrer"
+           class="mt-2 inline-flex items-center gap-2 px-5 py-2 border border-forest-green/50 text-forest-green rounded-full text-sm font-medium hover:bg-forest-green/10 transition duration-200"
+           aria-label="{{ t.reviews.doctoraliaAriaLabel }}">
+            <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M20,2H4A2,2 0 0,0 2,4V22L6,18H20A2,2 0 0,0 22,16V4A2,2 0 0,0 20,2Z"/>
+            </svg>
+            <span>{{ t.reviews.doctoraliaCtaText }}</span>
         </a>
 
     </div>


### PR DESCRIPTION
## Summary
- Adds a secondary CTA in the reviews section (`#reviews`) below the existing Google Maps button
- Invites users who prefer anonymity to leave a review on Doctoralia
- Fixes pre-existing hardcoded aria-labels on both review buttons — moved into JSON data (`googleMapsAriaLabel`, `doctoraliaAriaLabel`)
- Doctoralia URL is currently set to `PLACEHOLDER_DOCTORALIA_URL` and must be replaced before merging

## Test plan
- [ ] Replace `PLACEHOLDER_DOCTORALIA_URL` in `es.json` and `en.json` with the real Doctoralia review URL
- [ ] `npm run build` succeeds without errors
- [ ] Spanish `/` and English `/en/` both show both review CTAs
- [ ] Doctoralia button is visually secondary (outlined) vs Google Maps (solid)
- [ ] Both buttons have correct aria-labels in their respective languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)